### PR TITLE
Add stdint header to vlog_memory_workload main

### DIFF
--- a/cuda/nsight_compute/vlog_memory_workload/src/main.cu
+++ b/cuda/nsight_compute/vlog_memory_workload/src/main.cu
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 #include "cuda_helper.cuh"
 #include "lodepng.h"


### PR DESCRIPTION
Fix compilation of vlog_memory_workload when stdint types such as uint8_t is not found.